### PR TITLE
Remove shouldHaveHeader

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ spec = before (return app) $ do
       get "/foo" `shouldRespondWith` "hello" {matchStatus = 200}
 
     it "has Content-Type: text/plain" $ do
-      get "/foo" `shouldHaveHeader` (hContentType, "text/plain")
+      get "/foo" `shouldRespondWith` 200 {matchHeaders = [(hContentType, "text/plain")]}
 ~~~
 
 ## Contributing

--- a/src/Test/Hspec/Wai.hs
+++ b/src/Test/Hspec/Wai.hs
@@ -5,7 +5,6 @@ module Test.Hspec.Wai (
 , post
 , put
 , request
-, shouldHaveHeader
 , shouldRespondWith
 , ResponseMatcher(..)
 ) where
@@ -25,13 +24,6 @@ import           Test.Hspec.Wai.Matcher
 
 with :: IO a -> SpecWith a -> Spec
 with = before
-
--- |
--- Passes if the given `Header` exists in the response.
-shouldHaveHeader :: WaiSession SResponse -> Header -> WaiExpectation
-shouldHaveHeader action header = do
-  r <- action
-  forM_ (haveHeader r header) (liftIO . expectationFailure)
 
 -- |
 -- Passs if

--- a/src/Test/Hspec/Wai/Matcher.hs
+++ b/src/Test/Hspec/Wai/Matcher.hs
@@ -1,7 +1,6 @@
 module Test.Hspec.Wai.Matcher (
   ResponseMatcher(..)
 , match
-, haveHeader
 ) where
 
 
@@ -10,7 +9,6 @@ import           Data.Monoid
 import           Data.Functor
 import           Data.String
 import           Data.Text.Lazy.Encoding (encodeUtf8)
-import qualified Data.ByteString.Char8 as B
 import qualified Data.ByteString.Lazy as LB
 import           Network.HTTP.Types
 import           Network.Wai.Test
@@ -64,14 +62,3 @@ checkHeaders actual expected = case filter (`notElem` actual) expected of
     in Just $ unlines (msg : formatHeaders missing ++ "the actual headers were:" : formatHeaders actual)
   where
     formatHeaders = map (("  " ++) . formatHeader)
-
-haveHeader :: SResponse -> Header -> Maybe String
-haveHeader (SResponse _ headers _) (name, expected) = go $ lookup name headers
-  where
-    go Nothing = Just $ "header doesn't exist: " ++ show name
-    go (Just actual) = if actual == expected
-                         then Nothing
-                         else (Just . unlines) [ "header mismatch"
-                                               , "  expected: \"" ++ B.unpack expected ++ "\""
-                                               , "  but got:  \"" ++ B.unpack actual ++ "\""
-                                               ]

--- a/test/Test/Hspec/Wai/MatcherSpec.hs
+++ b/test/Test/Hspec/Wai/MatcherSpec.hs
@@ -80,23 +80,3 @@ spec = do
               , "the actual headers were:"
               , "  Content-Length: 23"
               ]
-
-  describe "haveHeader" $ do
-    context "if expected header exists in actual response" $ do
-      it "should be ok" $ do
-        SResponse status200 [(hContentType, "text/plain" )] "" `haveHeader` (hContentType, "text/plain")
-          `shouldBe` Nothing
-
-    context "if expected header does not exist" $ do
-      it "should be ok" $ do
-        SResponse status200 [(hLocation, "http://example.com" )] "" `haveHeader` (hContentType, "text/plain")
-          `shouldBe` Just ("header doesn't exist: " ++ show hContentType)
-
-    context "if expected header has different value" $ do
-      it "should be ok" $ do
-        SResponse status200 [(hContentType, "image/jpeg" )] "" `haveHeader` (hContentType, "text/plain")
-          `shouldBe` (Just . unlines) [
-            "header mismatch"
-          , "  expected: \"text/plain\""
-          , "  but got:  \"image/jpeg\""
-          ]


### PR DESCRIPTION
Header matching is now support by the ResponseMatcher.
