### PR TITLE
fix example for header matching in comment

### DIFF
--- a/src/Test/Hspec/Wai.hs
+++ b/src/Test/Hspec/Wai.hs
@@ -74,7 +74,7 @@ with = before
 -- If you want to require a specific header field you can specify
 -- `matchHeaders`:
 --
--- > get "/" `shouldRespondWith` "foo" {matchHeaders = "Content-Type: text/plain"}
+-- > get "/" `shouldRespondWith` "foo" {matchHeaders = [("Content-Type", "text/plain")]}
 -- > -- matches if body is "foo", status is 200 and ther is a header field "Content-Type: text/plain"
 shouldRespondWith :: WaiSession SResponse -> ResponseMatcher -> WaiExpectation
 shouldRespondWith action matcher = do


### PR DESCRIPTION
That example is wrong, isn't it?
