### PR TITLE
change post to use the specified default Content-Type header so the

### DIFF
--- a/src/Test/Hspec/Wai.hs
+++ b/src/Test/Hspec/Wai.hs
@@ -95,9 +95,13 @@ shouldRespondWith action matcher = do
 get :: ByteString -> WaiSession SResponse
 get path = request methodGet path [] ""
 
--- | Perform a @POST@ request to the application under test.
-post :: ByteString -> LB.ByteString -> WaiSession SResponse
-post path = request methodPost path []
+-- | Perform a @POST@ request to the application under test using the default
+-- Content-Type header application/x-www.form-urlencoded.
+post :: ByteString -- ^ Path
+     -> LB.ByteString -- ^ Body, form-urlencoded
+     -> WaiSession SResponse
+post path = request methodPost path [("Content-Type",
+                                      "application/x-www-form-urlencoded")]
 
 -- | Perform a @PUT@ request to the application under test.
 put :: ByteString -> LB.ByteString -> WaiSession SResponse


### PR DESCRIPTION
change post to use the specified default Content-Type header so the body will be parsed by wai as params.
