### PR TITLE
Add helpers for HTTP methods taking params

### DIFF
--- a/src/Test/Hspec/Wai.hs
+++ b/src/Test/Hspec/Wai.hs
@@ -16,11 +16,6 @@ module Test.Hspec.Wai (
 
 -- ** Performing requests with encoded parameters
 , postWithParams
-, postWithParams'
-, putWithParams
-, putWithParams'
-, patchWithParams
-, patchWithParams'
 
 -- * Matching on the response
 , shouldRespondWith
@@ -127,44 +122,9 @@ request method path headers body = getApp >>= liftIO . runSession (Wai.srequest 
     req = setPath defaultRequest {requestMethod = method, requestHeaders = headers} path
 
 -- | Perform a @POST@ request to the application under test with a list of
--- parameters to be encoded, including empty parameters.
-postWithParams :: ByteString -> Query -> WaiSession SResponse
-postWithParams = requestWithParams methodPost
-
--- | Perform a @POST@ request to the application under test with a list of
--- non-empty parameters to be encoded.
-postWithParams' :: ByteString -> SimpleQuery -> WaiSession SResponse
-postWithParams' = requestWithParams' methodPost
-
--- | Perform a @PUT@ request to the application under test with a list of
--- parameters to be encoded, including empty parameters.
-putWithParams :: ByteString -> Query -> WaiSession SResponse
-putWithParams = requestWithParams methodPut
-
--- | Perform a @PUT@ request to the application under test with a list of
--- non-empty parameters to be encoded.
-putWithParams' :: ByteString -> SimpleQuery -> WaiSession SResponse
-putWithParams' = requestWithParams' methodPut
-
--- | Perform a @PATCH@ request to the application under test with a list of
--- parameters to be encoded, including empty parameters.
-patchWithParams :: ByteString -> Query -> WaiSession SResponse
-patchWithParams = requestWithParams methodPatch
-
--- | Perform a @PATCH@ request to the application under test with a list of
--- non-empty parameters to be encoded.
-patchWithParams' :: ByteString -> SimpleQuery -> WaiSession SResponse
-patchWithParams' = requestWithParams' methodPatch
-
-requestWithParams :: Method -> ByteString -> Query -> WaiSession SResponse
-requestWithParams method path = request method path formEncoded . encodeParams
+-- key-value tuples to be encoded as query parameters
+postWithParams :: ByteString -> SimpleQuery -> WaiSession SResponse
+postWithParams path = request methodPost path formHeaders . encodeParams
   where
-   encodeParams = LB.fromStrict . renderQuery False
-
-requestWithParams' :: Method -> ByteString -> SimpleQuery -> WaiSession SResponse
-requestWithParams' method path = request method path formEncoded . encodeParams
-  where
-   encodeParams = LB.fromStrict . renderSimpleQuery False
-
-formEncoded :: [Header]
-formEncoded = [(hContentType, "application/x-www-form-urlencoded")]
+    encodeParams = LB.fromStrict . renderSimpleQuery False
+    formHeaders  = [(hContentType, "application/x-www-form-urlencoded")]

--- a/test/Test/Hspec/WaiSpec.hs
+++ b/test/Test/Hspec/WaiSpec.hs
@@ -51,36 +51,16 @@ spec = do
       it "sends method, path, headers, and body" $
         request methodGet "/foo" jsonAccept (BL.fromChunks [jsonBody]) `shouldRespondWith` 200
 
-  describe "request functions with with encoded params" $ do
+  describe "request functions with with encoded params" $
 
     describe "postWithParams" $ with (return $ expectRequest methodPost "/foo" formBody formEncoded) $
       it "sends a post request with form-encoded params" $
-        postWithParams "/foo" params `shouldRespondWith` 200
+        postWithParams "/foo" queryParams `shouldRespondWith` 200
 
-    describe "postWithParams'" $ with (return $ expectRequest methodPost "/foo" formBody formEncoded) $
-      it "sends a post request with non-empty form-encoded params" $
-        postWithParams' "/foo" params' `shouldRespondWith` 200
-
-    describe "putWithParams" $ with (return $ expectRequest methodPut "/foo" formBody formEncoded) $
-      it "sends a put request with form-encoded params" $
-        putWithParams "/foo" params `shouldRespondWith` 200
-
-    describe "putWithParams'" $ with (return $ expectRequest methodPut "/foo" formBody formEncoded) $
-      it "sends a put request with non-empty form-encoded params" $
-        putWithParams' "/foo" params' `shouldRespondWith` 200
-
-    describe "patchWithParams" $ with (return $ expectRequest methodPatch "/foo" formBody formEncoded) $
-      it "sends a patch request with form-encoded params" $
-        patchWithParams "/foo" params `shouldRespondWith` 200
-
-    describe "patchWithParams'" $ with (return $ expectRequest methodPatch "/foo" formBody formEncoded) $
-      it "sends a patch request with non-empty form-encoded params" $
-        patchWithParams' "/foo" params' `shouldRespondWith` 200
 
   where
     jsonAccept = [(hAccept, "application/json")]
     jsonBody = "{\"foo\": 1}"
     formEncoded = [(hContentType, "application/x-www-form-urlencoded")]
     formBody = "foo=1"
-    params = [("foo", Just "1")]
-    params' = [("foo", "1")]
+    queryParams = [("foo", "1")]


### PR DESCRIPTION
Add versions of `post`, `put`, `patch` which take parameters in a
form-encoded format. These functions take a list of key/values, generate
the bytestring body, and supply the requiste headers for WAI.
