### PR TITLE
match Content-Type values case-insensitive

### DIFF
--- a/hspec-wai-json/hspec-wai-json.cabal
+++ b/hspec-wai-json/hspec-wai-json.cabal
@@ -30,6 +30,7 @@ library
     , template-haskell
     , aeson
     , aeson-qq >= 0.7.3
+    , case-insensitive >= 1.2.0.4 
 
 test-suite spec
   type:

--- a/hspec-wai-json/src/Test/Hspec/Wai/JSON.hs
+++ b/hspec-wai-json/src/Test/Hspec/Wai/JSON.hs
@@ -5,11 +5,13 @@ module Test.Hspec.Wai.JSON (
 , FromValue(..)
 ) where
 
+import           Control.Arrow (second)
 import           Data.List
 import           Data.ByteString.Lazy (ByteString)
 import qualified Data.ByteString.Lazy as BL
 import           Data.Aeson (Value, encode)
 import           Data.Aeson.QQ
+import qualified Data.CaseInsensitive as CI
 import           Language.Haskell.TH.Quote
 
 import           Test.Hspec.Wai
@@ -59,7 +61,8 @@ instance FromValue ResponseMatcher where
       body = fromValue v
       permissibleHeaders = addIfASCII ("Content-Type", "application/json") [("Content-Type", "application/json; charset=utf-8")]
       addIfASCII h = if BL.all (< 128) body then (h :) else id
-      p headers = if any (`elem` permissibleHeaders) headers
+      ciHeaderFields = map (second CI.mk)
+      p headers = if any (`elem` ciHeaderFields permissibleHeaders) (ciHeaderFields headers)
         then Nothing
         else (Just . unlines) ("missing header:" : (intersperse "  OR" $ map formatHeader permissibleHeaders))
 

--- a/hspec-wai-json/test/Test/Hspec/Wai/JSONSpec.hs
+++ b/hspec-wai-json/test/Test/Hspec/Wai/JSONSpec.hs
@@ -21,6 +21,9 @@ spec = do
         it "accepts 'application/json; charset=utf-8'" $ do
           matcher [("Content-Type", "application/json; charset=utf-8")] `shouldBe` Nothing
 
+        it "accepts 'application/json; charset=utf-8' case-insensitive" $ do
+          matcher [("Content-Type", "application/JSON; charset=UTF-8")] `shouldBe` Nothing
+
         it "rejects other headers" $ do
           matcher [("Content-Type", "foobar")] `shouldBe` (Just . unlines) [
               "missing header:"
@@ -38,4 +41,7 @@ spec = do
             ]
 
         it "accepts 'application/json; charset=utf-8'" $ do
+          matcher [("Content-Type", "application/json; charset=utf-8")] `shouldBe` Nothing
+
+        it "accepts 'application/json; charset=UTF-8' case-insensitive" $ do
           matcher [("Content-Type", "application/json; charset=utf-8")] `shouldBe` Nothing


### PR DESCRIPTION
header fields for Content-Type are case-insensitive
for example: `application/JSON` equals `application/json`