### PR TITLE
added Test.Hspec.Wai.Server

### DIFF
--- a/hspec-wai.cabal
+++ b/hspec-wai.cabal
@@ -39,15 +39,18 @@ library
     , transformers
     , case-insensitive
     , http-types
+    , network
     , wai >= 3
     , wai-extra >= 3
+    , warp
     , hspec-core == 2.*
     , hspec-expectations
     , QuickCheck
   exposed-modules:
       Test.Hspec.Wai
-      Test.Hspec.Wai.QuickCheck
       Test.Hspec.Wai.Internal
+      Test.Hspec.Wai.QuickCheck
+      Test.Hspec.Wai.Server
   other-modules:
       Test.Hspec.Wai.Matcher
       Test.Hspec.Wai.Util
@@ -68,20 +71,26 @@ test-suite spec
     , transformers
     , case-insensitive
     , http-types
+    , network
     , wai >= 3
     , wai-extra >= 3
+    , warp
     , hspec-core == 2.*
     , hspec-expectations
     , QuickCheck
     , hspec
     , QuickCheck
+    , process
+    , silently
   other-modules:
       Test.Hspec.Wai
       Test.Hspec.Wai.Internal
       Test.Hspec.Wai.Matcher
       Test.Hspec.Wai.QuickCheck
+      Test.Hspec.Wai.Server
       Test.Hspec.Wai.Util
       Test.Hspec.Wai.MatcherSpec
+      Test.Hspec.Wai.ServerSpec
       Test.Hspec.Wai.UtilSpec
       Test.Hspec.WaiSpec
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -30,8 +30,10 @@ dependencies:
   - transformers
   - case-insensitive
   - http-types
+  - network
   - wai >= 3
   - wai-extra >= 3
+  - warp
   - hspec-core == 2.*
   - hspec-expectations
   - QuickCheck
@@ -39,8 +41,9 @@ dependencies:
 library:
   exposed-modules:
     - Test.Hspec.Wai
-    - Test.Hspec.Wai.QuickCheck
     - Test.Hspec.Wai.Internal
+    - Test.Hspec.Wai.QuickCheck
+    - Test.Hspec.Wai.Server
 
 tests:
   spec:
@@ -49,3 +52,5 @@ tests:
     dependencies:
       - hspec
       - QuickCheck
+      - process
+      - silently

--- a/src/Test/Hspec/Wai/Server.hs
+++ b/src/Test/Hspec/Wai/Server.hs
@@ -1,0 +1,83 @@
+
+module Test.Hspec.Wai.Server (
+  withApplication,
+  openFreePort,
+) where
+
+import           Control.Concurrent
+import           Control.Exception
+import           Network.Socket
+import           Network.Wai
+import           Network.Wai.Handler.Warp
+
+data App
+  = App {
+    appThread :: ThreadId,
+    appWaitForKilled :: IO (),
+    appExceptionMVar :: MVar (Maybe SomeException),
+    appPort :: Int
+  }
+
+-- | Allows to test 'Application's over a real network port.
+--
+-- Runs the given 'Application' on a free port. Passes the free port to the
+-- given operation and executes it.
+withApplication :: IO Application -> (Port -> IO a) -> IO a
+withApplication mkApp action = do
+  app <- mkApp
+  bracket (acquire app) free (\ runningApp -> action (appPort runningApp))
+  where
+    acquire :: Application -> IO App
+    acquire app = do
+      start <- mkWaiter
+      killed <- mkWaiter
+      exceptionMVar_ <- newMVar Nothing
+      thread <- forkIO $ do
+        (port, sock) <- openFreePort
+        let settings =
+              setBeforeMainLoop (notify start port)
+              defaultSettings
+        runSettingsSocket settings sock (handleApp exceptionMVar_ app)
+          `finally` notify killed ()
+      port <- waitFor start
+      return $ App thread (waitFor killed) exceptionMVar_ port
+
+    free :: App -> IO ()
+    free runningApp = do
+      killThread $ appThread runningApp
+      appWaitForKilled runningApp
+      exception <- readMVar (appExceptionMVar runningApp)
+      case exception of
+        Nothing -> return ()
+        Just e -> throwIO e
+
+handleApp :: MVar (Maybe SomeException) -> Application -> Application
+handleApp mvar app request respond = do
+  catch (app request respond) $ \ e -> do
+    modifyMVar_ mvar $ \ _ ->
+      return (Just e)
+    throwIO e
+
+data Waiter a
+  = Waiter {
+    notify :: a -> IO (),
+    waitFor :: IO a
+  }
+
+mkWaiter :: IO (Waiter a)
+mkWaiter = do
+  mvar <- newEmptyMVar
+  return $ Waiter {
+    notify = putMVar mvar,
+    waitFor = readMVar mvar
+  }
+
+-- | Opens a socket on a free port returns both port and socket.
+openFreePort :: IO (Port, Socket)
+openFreePort = do
+  s <- socket AF_INET Stream defaultProtocol
+  localhost <- inet_addr "127.0.0.1"
+  bind s (SockAddrInet aNY_PORT localhost)
+  listen s 1
+  port <- socketPort s
+  return (fromIntegral port, s)

--- a/test/Test/Hspec/Wai/ServerSpec.hs
+++ b/test/Test/Hspec/Wai/ServerSpec.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.Hspec.Wai.ServerSpec where
+
+import           Control.Exception
+import           Network.HTTP.Types
+import           Network.Wai
+import           System.IO.Silently
+import           System.Process
+import           Test.Hspec
+
+import           Test.Hspec.Wai.Server
+
+spec :: Spec
+spec = do
+  describe "withApplication" $ do
+    it "runs a wai Application while executing the given action" $ do
+      let mkApp = return $ \ _request respond -> respond $ responseLBS ok200 [] "foo"
+      withApplication mkApp $ \ port -> do
+        output <- silence $ readProcess "curl" ["localhost:" ++ show port] ""
+        output `shouldBe` "foo"
+
+    it "propagates exceptions from the server to the executing thread" $ do
+      let mkApp = return $ \ _request _respond -> throwIO $ ErrorCall "foo"
+      (withApplication mkApp $ \ port -> do
+          silence $ readProcess "curl" ["localhost:" ++ show port] "")
+        `shouldThrow` (== ErrorCall "foo")


### PR DESCRIPTION
This commit adds a helper function that allows to test wai `Application`s over a real port. This is very different from the approach in `Test.Hspec.Wai` but I still think this is the best place for this helper function.
