### PR TITLE
Fixed #29 (Allow partial body matching)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /dist/
 /hspec-wai-json/dist/
+.stack-work
+/hspec-wai-json/.stack-work

--- a/hspec-wai-json/hspec-wai-json.cabal
+++ b/hspec-wai-json/hspec-wai-json.cabal
@@ -34,6 +34,7 @@ library
     , bytestring
     , template-haskell
     , aeson
+    , http-types
     , aeson-qq >= 0.7.3
     , case-insensitive
   ghc-options: -Wall

--- a/src/Test/Hspec/Wai.hs
+++ b/src/Test/Hspec/Wai.hs
@@ -21,6 +21,7 @@ module Test.Hspec.Wai (
 
 -- * Matching on the response
 , shouldRespondWith
+, shouldContainInBody
 , ResponseMatcher(..)
 , MatchHeader(..)
 , (<:>)
@@ -101,6 +102,11 @@ shouldRespondWith :: WithLocation (WaiSession SResponse -> ResponseMatcher -> Wa
 shouldRespondWith action matcher = do
   r <- action
   forM_ (match r matcher) (liftIO . expectationFailure)
+
+shouldContainInBody :: WithLocation (WaiSession SResponse -> ResponseMatcher -> WaiExpectation)
+shouldContainInBody action matcher = do
+  r <- action
+  forM_ (match r matcher { matchPartialBody = True }) (liftIO . expectationFailure)
 
 -- | Perform a @GET@ request to the application under test.
 get :: ByteString -> WaiSession SResponse

--- a/src/Test/Hspec/Wai.hs
+++ b/src/Test/Hspec/Wai.hs
@@ -103,6 +103,7 @@ shouldRespondWith action matcher = do
   r <- action
   forM_ (match r matcher) (liftIO . expectationFailure)
 
+-- | Like `shouldRespondWith`, but matches if the body contains the input string, wholly and intact.
 shouldContainInBody :: WithLocation (WaiSession SResponse -> ResponseMatcher -> WaiExpectation)
 shouldContainInBody action matcher = do
   r <- action

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,6 @@
+resolver: lts-5.8
+packages:
+  - '.'
+  - 'hspec-wai-json'
+extra-deps:
+  - with-location-0.1.0


### PR DESCRIPTION
Hey @sol , long time no chat!

At work I needed a matcher to be able to match only part of the http response body, and having noticed there was interest in such feature (see #29) I took at crack at it.

My implementation is very simple, so feel free to suggest amendment to it. 
It works nicely, also in conjunction with other `QuasiQuoter`s, like `Text.RawString.QQ` (**misc screenshots follow, they do not follow any precise workflow or ordering**):

![screen shot 2016-03-16 at 14 50 57](https://cloud.githubusercontent.com/assets/442035/13814490/cce59aea-eb86-11e5-83f1-cb0923e06e1d.png)

![screen shot 2016-03-16 at 14 49 05](https://cloud.githubusercontent.com/assets/442035/13814496/d3a82258-eb86-11e5-9c36-ca489e5ba7e2.png)

![screen shot 2016-03-16 at 14 43 26](https://cloud.githubusercontent.com/assets/442035/13814515/db1a7f86-eb86-11e5-8df5-7e2b235eb7a6.png)

![screen shot 2016-03-16 at 14 43 10](https://cloud.githubusercontent.com/assets/442035/13814526/e17351a0-eb86-11e5-843a-33e0f321074a.png)

What would you like to see in terms of extra stuff (docs, tests, etc) to consider this mergeable?
I have also added support for building this with `stack` but I hardly think it's a problem!

Thank you!

Alfredo