### PR TITLE
Match JSON content type per RFC

### DIFF
--- a/hspec-wai-json/hspec-wai-json.cabal
+++ b/hspec-wai-json/hspec-wai-json.cabal
@@ -33,6 +33,7 @@ library
       base == 4.*
     , hspec-wai == 0.6.*
     , bytestring
+    , http-media
     , template-haskell
     , aeson
     , aeson-qq >= 0.7.3

--- a/hspec-wai-json/package.yaml
+++ b/hspec-wai-json/package.yaml
@@ -24,6 +24,7 @@ library:
     - base == 4.*
     - hspec-wai == 0.6.*
     - bytestring
+    - http-media
     - template-haskell
     - aeson
     - aeson-qq >= 0.7.3

--- a/hspec-wai-json/src/Test/Hspec/Wai/JSON.hs
+++ b/hspec-wai-json/src/Test/Hspec/Wai/JSON.hs
@@ -5,7 +5,6 @@ module Test.Hspec.Wai.JSON (
 , FromValue(..)
 ) where
 
-import           Control.Arrow (second)
 import           Data.List
 import           Data.Maybe (isJust)
 import           Data.ByteString.Lazy (ByteString)
@@ -16,7 +15,6 @@ import           Language.Haskell.TH.Quote
 import           Network.HTTP.Media
 
 import           Test.Hspec.Wai
-import           Test.Hspec.Wai.Internal (formatHeader)
 import           Test.Hspec.Wai.Matcher
 
 -- $setup

--- a/hspec-wai-json/src/Test/Hspec/Wai/JSON.hs
+++ b/hspec-wai-json/src/Test/Hspec/Wai/JSON.hs
@@ -7,12 +7,13 @@ module Test.Hspec.Wai.JSON (
 
 import           Control.Arrow (second)
 import           Data.List
+import           Data.Maybe (isJust)
 import           Data.ByteString.Lazy (ByteString)
 import qualified Data.ByteString.Lazy as BL
 import           Data.Aeson (Value, decode, encode)
 import           Data.Aeson.QQ
-import qualified Data.CaseInsensitive as CI
 import           Language.Haskell.TH.Quote
+import           Network.HTTP.Media
 
 import           Test.Hspec.Wai
 import           Test.Hspec.Wai.Internal (formatHeader)
@@ -59,13 +60,15 @@ class FromValue a where
 instance FromValue ResponseMatcher where
   fromValue = ResponseMatcher 200 [MatchHeader p] . equalsJSON
     where
-      p headers body = if any (`elem` mkCI permissibleHeaders) (mkCI headers)
+      p headers body = if any isJsonCT headers
         then Nothing
-        else (Just . unlines) ("missing header:" : (intersperse "  OR" $ map formatHeader permissibleHeaders))
+        else (Just . unlines) ("wrong Content-Type value, should be:" : (map ("  " ++) $ intersperse "OR" $ map show acceptableCT))
         where
-          mkCI = map (second CI.mk)
-          permissibleHeaders = addIfASCII ("Content-Type", "application/json") [("Content-Type", "application/json; charset=utf-8")]
-          addIfASCII h = if BL.all (< 128) body then (h :) else id
+          isJsonCT ("Content-Type", ct) = isJust $ matchContent acceptableCT ct
+          isJsonCT _ = False
+          jsonCT = "application" // "json"
+          jsonCharsetCT = jsonCT /: ("charset","utf-8")
+          acceptableCT = if BL.all (< 128) body then [jsonCT, jsonCharsetCT] else [jsonCharsetCT]
 
 equalsJSON :: Value -> MatchBody
 equalsJSON expected = MatchBody matcher

--- a/hspec-wai-json/test/Test/Hspec/Wai/JSONSpec.hs
+++ b/hspec-wai-json/test/Test/Hspec/Wai/JSONSpec.hs
@@ -50,6 +50,12 @@ spec = do
         it "ignores case" $ do
           match [("Content-Type", "application/JSON; charset=UTF-8")] `shouldBe` Nothing
 
+        it "doesn't require space before charset" $ do
+          match [("Content-Type", "application/json;charset=utf-8")] `shouldBe` Nothing
+
+        it "ignores extra whitespace" $ do
+          match [("Content-Type", "application/json;   charset=utf-8")] `shouldBe` Nothing
+
         it "rejects other headers" $ do
           match [("Content-Type", "foobar")] `shouldBe` (Just . unlines) [
               "missing header:"

--- a/hspec-wai-json/test/Test/Hspec/Wai/JSONSpec.hs
+++ b/hspec-wai-json/test/Test/Hspec/Wai/JSONSpec.hs
@@ -58,10 +58,10 @@ spec = do
 
         it "rejects other headers" $ do
           match [("Content-Type", "foobar")] `shouldBe` (Just . unlines) [
-              "missing header:"
-            , "  Content-Type: application/json"
+              "wrong Content-Type value, should be:"
+            , "  application/json"
             , "  OR"
-            , "  Content-Type: application/json; charset=utf-8"
+            , "  application/json;charset=utf-8"
             ]
 
       context "when body is UTF-8" $ do
@@ -71,9 +71,9 @@ spec = do
 
         it "rejects 'application/json'" $ do
           match [("Content-Type", "application/json")] `shouldBe` (Just . unlines) [
-              "missing header:"
-            , "  Content-Type: application/json; charset=utf-8"
+              "wrong Content-Type value, should be:"
+            , "  application/json;charset=utf-8"
             ]
 
         it "accepts 'application/json; charset=utf-8'" $ do
-          match [("Content-Type", "application/json; charset=utf-8")] `shouldBe` Nothing
+          match [("Content-Type", "application/json;charset=utf-8")] `shouldBe` Nothing


### PR DESCRIPTION
Ignore insignificant spaces in `Content-Type` header when checking for JSON.

Fixes #6.