### PR TITLE
Allow "charset=utf8" parameter in json content type

### DIFF
--- a/hspec-wai-json/test/Test/Hspec/Wai/JSONSpec.hs
+++ b/hspec-wai-json/test/Test/Hspec/Wai/JSONSpec.hs
@@ -48,6 +48,12 @@ spec = do
           match [("Content-Type", "application/json;charset=utf-8")]
             `shouldBe` Nothing
 
+        it "requires a content-type header" $ do
+          match [] `shouldBe` (Just. unlines) [
+              "missing header:"
+            , "  Content-Type: application/json"
+            ]
+
         it "rejects other headers" $ do
           match [("Content-Type", "foobar")] `shouldBe` (Just . unlines) [
               "missing header:"

--- a/hspec-wai-json/test/Test/Hspec/Wai/JSONSpec.hs
+++ b/hspec-wai-json/test/Test/Hspec/Wai/JSONSpec.hs
@@ -44,11 +44,9 @@ spec = do
         it "accepts 'application/json'" $ do
           match [("Content-Type", "application/json")] `shouldBe` Nothing
 
-        it "accepts 'application/json; charset=utf-8'" $ do
-          match [("Content-Type", "application/json; charset=utf-8")] `shouldBe` (Just . unlines) [
-              "missing header:"
-            , "  Content-Type: application/json"
-            ]
+        it "accepts 'application/json;charset=utf-8'" $ do
+          match [("Content-Type", "application/json;charset=utf-8")]
+            `shouldBe` Nothing
 
         it "rejects other headers" $ do
           match [("Content-Type", "foobar")] `shouldBe` (Just . unlines) [

--- a/package.yaml
+++ b/package.yaml
@@ -42,6 +42,7 @@ library:
     - Test.Hspec.Wai.QuickCheck
     - Test.Hspec.Wai.Internal
     - Test.Hspec.Wai.Matcher
+    - Test.Hspec.Wai.Util
 
 tests:
   spec:


### PR DESCRIPTION
Even though charset isn't a defined parameter for the application/json mime type, it is in use and servant sends it (see e.g. https://github.com/haskell-servant/servant/issues/849). Also, the [JSON rfc](https://tools.ietf.org/html/rfc7159) remarks that it should be ignored:

> Note: No "charset" parameter is defined for this registration.
> Adding one really has no effect on compliant recipients.

This patch changes the json matcher to accept both variants ("application/json" and "application/json;charset=utf-8") so that the library works with servant out of the box. 