### PR TITLE
Hedgehog state machine

### DIFF
--- a/hspec-wai.cabal
+++ b/hspec-wai.cabal
@@ -37,6 +37,7 @@ library
     , base-compat
     , bytestring >=0.10
     , case-insensitive
+    , exceptions >=0.1.1 && <1
     , hspec-core ==2.*
     , hspec-expectations >=0.8.0
     , http-types

--- a/hspec-wai.cabal
+++ b/hspec-wai.cabal
@@ -68,6 +68,7 @@ test-suite spec
     , base-compat
     , bytestring >=0.10
     , case-insensitive
+    , exceptions >=0.1.1 && <1
     , hspec
     , hspec-core ==2.*
     , hspec-expectations >=0.8.0

--- a/src/Test/Hspec/Wai.hs
+++ b/src/Test/Hspec/Wai.hs
@@ -34,6 +34,7 @@ module Test.Hspec.Wai (
 , with
 , pending
 , pendingWith
+, runWaiSession
 ) where
 
 import           Data.Foldable

--- a/src/Test/Hspec/Wai/Internal.hs
+++ b/src/Test/Hspec/Wai/Internal.hs
@@ -14,6 +14,7 @@ module Test.Hspec.Wai.Internal (
 import           Prelude ()
 import           Prelude.Compat
 
+import           Control.Monad.Catch (MonadCatch, MonadThrow)
 import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Reader
 import           Network.Wai (Application)
@@ -29,7 +30,7 @@ type WaiExpectation = WaiSession ()
 -- | A <http://www.yesodweb.com/book/web-application-interface WAI> test
 -- session that carries the `Application` under test and some client state.
 newtype WaiSession a = WaiSession {unWaiSession :: Session a}
-  deriving (Functor, Applicative, Monad, MonadIO)
+  deriving (Functor, Applicative, Monad, MonadIO, MonadThrow, MonadCatch)
 
 runWaiSession :: WaiSession a -> Application -> IO a
 runWaiSession = runSession . unWaiSession

--- a/src/Test/Hspec/Wai/Internal.hs
+++ b/src/Test/Hspec/Wai/Internal.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeFamilies #-}
 module Test.Hspec.Wai.Internal (
   WaiExpectation


### PR DESCRIPTION
These were the changes I needed to make in order to use `hspec-wai`'s testing combinators with hedgehog state machine testing. The important changes are:

1. Add `MonadCatch` and `MonadThrow` instances for `WaiSession`, as these are required by `executeSequential` in hedgehog and already implemented for `Session`.
2. Export `runWaiSession` from `Test.Hspec.Wai` so the `WaiSession` may be run once the test actions have been built.

I'm aware that `runWaiSession` can be imported from `Test.Hspec.Wai.Internal`, but given its importance I thought it made sense to make it part of the public API.