### PR TITLE
Post json function

### DIFF
--- a/src/Test/Hspec/Wai.hs
+++ b/src/Test/Hspec/Wai.hs
@@ -20,6 +20,9 @@ module Test.Hspec.Wai (
 -- ** Posting HTML forms
 , postHtmlForm
 
+-- ** Posting Json
+, postJson
+
 -- * Matching on the response
 , shouldRespondWith
 
@@ -144,3 +147,9 @@ request method path headers body = getApp >>= liftIO . runSession (Wai.srequest 
 -- In addition the @Content-Type@ is set to @application/x-www-form-urlencoded@.
 postHtmlForm :: ByteString -> [(String, String)] -> WaiSession SResponse
 postHtmlForm path = request methodPost path [(hContentType, "application/x-www-form-urlencoded")] . formUrlEncodeQuery
+
+-- | Perform a @POST@ request to the application under test.
+--
+-- The @Content-Type@ is set to @application/json@.
+postJson :: ByteString -> LB.ByteString -> WaiSession SResponse
+postJson path = request methodPost path [(hContentType, "application/json")]

--- a/test/Test/Hspec/WaiSpec.hs
+++ b/test/Test/Hspec/WaiSpec.hs
@@ -64,7 +64,12 @@ spec = do
     it "sends a post request with form-encoded params" $ do
       postHtmlForm "/foo" [("foo", "bar")] `shouldRespondWith` 200
 
+  describe "postJson" $ with (return $ expectRequest methodPost "/foo" body jsonContentType) $ do
+    it "sends a post request with json" $ do
+      postJson "/foo" "{\"foo\": 1}" `shouldRespondWith` 200
+
   where
     accept = [(hAccept, "application/json")]
     body = "{\"foo\": 1}"
     formEncoded = [(hContentType, "application/x-www-form-urlencoded")]
+    jsonContentType = [(hContentType, "application/json")]


### PR DESCRIPTION
This pr is inspired by https://github.com/hspec/hspec-wai/issues/51, thanks @jinilover @diegospd!

I added `postJson` for convinient use to test `post` with `JSON`.