### PR TITLE
Re-export SResponse from Test.Hspec.Wai

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+## Changes in 0.12.0
+  - Re-export `Network.Wai.Test.SResponse` from `Test.Hspec.Wai` (https://github.com/hspec/hspec-wai/issues/79)
+
 ## Changes in 0.11.0
   - Add support for cookies
   - Drop support for GHC <8

--- a/hspec-wai-json/hspec-wai-json.cabal
+++ b/hspec-wai-json/hspec-wai-json.cabal
@@ -1,62 +1,62 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.38.3.
 --
 -- see: https://github.com/sol/hpack
 
-name:             hspec-wai-json
-version:          0.11.1
-homepage:         https://github.com/hspec/hspec-wai#readme
-bug-reports:      https://github.com/hspec/hspec-wai/issues
-license:          MIT
-license-file:     LICENSE
-copyright:        (c) 2012-2014 Fujimura Daisuke,
-                  (c) 2014-2018 Simon Hengel
-author:           Fujimura Daisuke <me@fujimuradaisuke.com>,
-                  Simon Hengel <sol@typeful.net>
-maintainer:       Fujimura Daisuke <me@fujimuradaisuke.com>,
-                  Simon Hengel <sol@typeful.net>
-build-type:       Simple
-category:         Testing
-synopsis:         Testing JSON APIs with hspec-wai
-description:      Testing JSON APIs with hspec-wai
+name:           hspec-wai-json
+version:        0.12.0
+synopsis:       Testing JSON APIs with hspec-wai
+description:    Testing JSON APIs with hspec-wai
+category:       Testing
+homepage:       https://github.com/hspec/hspec-wai#readme
+bug-reports:    https://github.com/hspec/hspec-wai/issues
+author:         Fujimura Daisuke <me@fujimuradaisuke.com>,
+                Simon Hengel <sol@typeful.net>
+maintainer:     Fujimura Daisuke <me@fujimuradaisuke.com>,
+                Simon Hengel <sol@typeful.net>
+copyright:      (c) 2012-2014 Fujimura Daisuke,
+                (c) 2014-2018 Simon Hengel
+license:        MIT
+license-file:   LICENSE
+build-type:     Simple
 
 source-repository head
   type: git
   location: https://github.com/hspec/hspec-wai
 
 library
-  hs-source-dirs:
-      src
   exposed-modules:
       Test.Hspec.Wai.JSON
   other-modules:
       Paths_hspec_wai_json
+  hs-source-dirs:
+      src
+  ghc-options: -Wall
   build-depends:
       aeson
     , aeson-qq >=0.7.3
     , base ==4.*
     , bytestring
     , case-insensitive
-    , hspec-wai ==0.11.1
+    , hspec-wai ==0.12.0
     , template-haskell
-  ghc-options: -Wall
   default-language: Haskell2010
 
 test-suite spec
   type: exitcode-stdio-1.0
-  hs-source-dirs:
-      test
   main-is: Spec.hs
   other-modules:
       Test.Hspec.Wai.JSONSpec
       Paths_hspec_wai_json
+  hs-source-dirs:
+      test
+  ghc-options: -Wall
+  build-tool-depends:
+      hspec-discover:hspec-discover
   build-depends:
       base ==4.*
     , hspec
     , hspec-wai
     , hspec-wai-json
-  ghc-options: -Wall
-  build-tool-depends:
-      hspec-discover:hspec-discover
   default-language: Haskell2010

--- a/hspec-wai-json/package.yaml
+++ b/hspec-wai-json/package.yaml
@@ -1,5 +1,5 @@
 name:             hspec-wai-json
-version:          0.11.1
+version:          0.12.0
 license:          MIT
 category:         Testing
 synopsis:         Testing JSON APIs with hspec-wai
@@ -22,7 +22,7 @@ library:
   source-dirs: src
   dependencies:
     - base == 4.*
-    - hspec-wai == 0.11.1
+    - hspec-wai == 0.12.0
     - bytestring
     - template-haskell
     - aeson

--- a/hspec-wai.cabal
+++ b/hspec-wai.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:             hspec-wai
-version:          0.11.1
+version:          0.12.0
 homepage:         https://github.com/hspec/hspec-wai#readme
 bug-reports:      https://github.com/hspec/hspec-wai/issues
 license:          MIT

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:             hspec-wai
-version:          0.11.1
+version:          0.12.0
 license:          MIT
 category:         Testing
 synopsis:         Experimental Hspec support for testing WAI applications

--- a/src/Test/Hspec/Wai.hs
+++ b/src/Test/Hspec/Wai.hs
@@ -37,6 +37,7 @@ module Test.Hspec.Wai (
 , getState
 , pending
 , pendingWith
+, SResponse(..)
 ) where
 
 import           Prelude ()


### PR DESCRIPTION
As discussed in #79.

Technically, the re-export could be a breaking change for anyone importing `Test.Hspec.Wai` unqualified (which I assume is the majority of users), so I conservatively went with a major version bump. If you feel like it's unnecessary here, I'd be fine with a minor bump as well.